### PR TITLE
feat: 일간, 주간, 월간, 연간 통계 집계 기능 구현

### DIFF
--- a/src/main/java/com/github/garamflow/streamsettlement/batch/processor/DailyLogProcessor.java
+++ b/src/main/java/com/github/garamflow/streamsettlement/batch/processor/DailyLogProcessor.java
@@ -1,52 +1,41 @@
 package com.github.garamflow.streamsettlement.batch.processor;
 
+import com.github.garamflow.streamsettlement.batch.util.StatisticsUtil;
 import com.github.garamflow.streamsettlement.entity.statistics.ContentStatistics;
-import com.github.garamflow.streamsettlement.entity.statistics.StatisticsPeriod;
 import com.github.garamflow.streamsettlement.entity.stream.Log.DailyMemberViewLog;
 import com.github.garamflow.streamsettlement.entity.stream.Log.StreamingStatus;
-import com.github.garamflow.streamsettlement.entity.stream.content.ContentPost;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.batch.core.configuration.annotation.StepScope;
 import org.springframework.batch.item.ItemProcessor;
 import org.springframework.lang.NonNull;
 import org.springframework.stereotype.Component;
 
+import java.util.List;
+
 @Slf4j
 @Component
 @StepScope
-public class DailyLogProcessor implements ItemProcessor<DailyMemberViewLog, ContentStatistics> {
+public class DailyLogProcessor implements ItemProcessor<DailyMemberViewLog, List<ContentStatistics>> {
 
-    @Override
-    public ContentStatistics process(@NonNull DailyMemberViewLog dailyLog) {
-        // 상태 확인
-        if (dailyLog.getStatus() != StreamingStatus.COMPLETED) {
-            log.warn("Skipping log with status {} for ID: {}", dailyLog.getStatus(), dailyLog.getId());
-            return null;
-        }
+  @Override
+  public List<ContentStatistics> process(@NonNull DailyMemberViewLog dailyLog) {
+      if (dailyLog.getStatus() != StreamingStatus.COMPLETED) {
+          log.warn("Skipping log with status {} for ID: {}", dailyLog.getStatus(), dailyLog.getId());
+          return null;
+      }
 
-        // ContentPost null 체크
-        ContentPost contentPost = dailyLog.getContentPost();
-        if (contentPost == null) {
-            log.error("ContentPost is null for DailyMemberViewLog ID: {}", dailyLog.getId());
-            throw new IllegalStateException("ContentPost cannot be null.");
-        }
+      if (dailyLog.getMember() == null) {
+          throw new IllegalStateException("member is null");
+      }
+      if (dailyLog.getContentPost() == null) {
+          throw new IllegalStateException("contentPost is null");
+      }
 
-        // Member null 체크
-        if (dailyLog.getMember() == null) {
-            log.error("Member is null for DailyMemberViewLog ID: {}", dailyLog.getId());
-            throw new IllegalStateException("DailyMemberViewLog contains null fields: member is null");
-        }
-
-        // ContentStatistics 생성
-        log.debug("Processing log ID: {}", dailyLog.getId());
-        return new ContentStatistics.Builder()
-                .contentPost(contentPost)
-                .statisticsDate(dailyLog.getLogDate())
-                .period(StatisticsPeriod.DAILY)
-                .viewCount(1L)
-                .watchTime((long) dailyLog.getLastViewedPosition())
-                .accumulatedViews(contentPost.getTotalViews())
-                .build();
-    }
+      return StatisticsUtil.createStatistics(
+              dailyLog.getContentPost(),
+              dailyLog.getLogDate(),
+              dailyLog.getLastViewedPosition()
+      );
+  }
 }
 

--- a/src/main/java/com/github/garamflow/streamsettlement/batch/reader/DailyLogReader.java
+++ b/src/main/java/com/github/garamflow/streamsettlement/batch/reader/DailyLogReader.java
@@ -75,7 +75,7 @@ public class DailyLogReader {
                 """);
         queryProvider.setWhereClause("""
                 d.log_date = :targetDate
-                AND d.content_post_id BETWEEN :minId AND :maxId
+                AND d.daily_member_view_log_id BETWEEN :minId AND :maxId
                 """);
         queryProvider.setSortKeys(Map.of("d.daily_member_view_log_id", Order.ASCENDING));
         return queryProvider;

--- a/src/main/java/com/github/garamflow/streamsettlement/batch/reader/mapper/DailyMemberViewLogRowMapper.java
+++ b/src/main/java/com/github/garamflow/streamsettlement/batch/reader/mapper/DailyMemberViewLogRowMapper.java
@@ -1,15 +1,12 @@
 package com.github.garamflow.streamsettlement.batch.reader.mapper;
 
 import com.github.garamflow.streamsettlement.entity.member.Member;
-import com.github.garamflow.streamsettlement.entity.member.Role;
 import com.github.garamflow.streamsettlement.entity.stream.Log.DailyMemberViewLog;
 import com.github.garamflow.streamsettlement.entity.stream.Log.StreamingStatus;
 import com.github.garamflow.streamsettlement.entity.stream.content.ContentPost;
 import com.github.garamflow.streamsettlement.repository.stream.ContentPostRepository;
 import com.github.garamflow.streamsettlement.repository.user.MemberRepository;
-
 import lombok.RequiredArgsConstructor;
-
 import org.springframework.jdbc.core.RowMapper;
 import org.springframework.stereotype.Component;
 
@@ -19,7 +16,7 @@ import java.sql.SQLException;
 @Component
 @RequiredArgsConstructor
 public class DailyMemberViewLogRowMapper implements RowMapper<DailyMemberViewLog> {
-    
+
     private final MemberRepository memberRepository;
     private final ContentPostRepository contentPostRepository;
 
@@ -28,7 +25,7 @@ public class DailyMemberViewLogRowMapper implements RowMapper<DailyMemberViewLog
         // 기존 엔티티를 조회
         Member member = memberRepository.findById(rs.getLong("member_id"))
                 .orElseThrow(() -> new IllegalStateException("Member not found"));
-        
+
         ContentPost contentPost = contentPostRepository.findById(rs.getLong("content_post_id"))
                 .orElseThrow(() -> new IllegalStateException("ContentPost not found"));
 

--- a/src/main/java/com/github/garamflow/streamsettlement/batch/util/StatisticsUtil.java
+++ b/src/main/java/com/github/garamflow/streamsettlement/batch/util/StatisticsUtil.java
@@ -1,0 +1,38 @@
+package com.github.garamflow.streamsettlement.batch.util;
+
+import com.github.garamflow.streamsettlement.entity.statistics.ContentStatistics;
+import com.github.garamflow.streamsettlement.entity.statistics.StatisticsPeriod;
+import com.github.garamflow.streamsettlement.entity.stream.content.ContentPost;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.temporal.TemporalAdjusters;
+import java.util.ArrayList;
+import java.util.List;
+
+public class StatisticsUtil {
+
+    public static List<ContentStatistics> createStatistics(ContentPost contentPost, LocalDate logDate, long watchTime) {
+        List<ContentStatistics> statistics = new ArrayList<>();
+        for (StatisticsPeriod period : StatisticsPeriod.getAllPeriodsForDaily()) {
+            statistics.add(new ContentStatistics.Builder()
+                    .contentPost(contentPost)
+                    .statisticsDate(getStatisticsDate(logDate, period))
+                    .period(period)
+                    .viewCount(1L)
+                    .watchTime(watchTime)
+                    .accumulatedViews(contentPost.getTotalViews())
+                    .build());
+        }
+        return statistics;
+    }
+
+    private static LocalDate getStatisticsDate(LocalDate logDate, StatisticsPeriod period) {
+        return switch (period) {
+            case DAILY -> logDate;
+            case WEEKLY -> logDate.with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY));
+            case MONTHLY -> logDate.withDayOfMonth(1);
+            case YEARLY -> logDate.withDayOfYear(1);
+        };
+    }
+}

--- a/src/main/java/com/github/garamflow/streamsettlement/batch/writer/DailyLogWriter.java
+++ b/src/main/java/com/github/garamflow/streamsettlement/batch/writer/DailyLogWriter.java
@@ -1,18 +1,23 @@
 package com.github.garamflow.streamsettlement.batch.writer;
 
 import com.github.garamflow.streamsettlement.entity.statistics.ContentStatistics;
+import com.github.garamflow.streamsettlement.entity.statistics.StatisticsPeriod;
 import com.github.garamflow.streamsettlement.entity.stream.content.ContentPost;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.batch.core.configuration.annotation.StepScope;
 import org.springframework.batch.item.Chunk;
 import org.springframework.batch.item.ItemWriter;
+import org.springframework.dao.CannotAcquireLockException;
+import org.springframework.data.util.Pair;
 import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Retryable;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Isolation;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.ArrayList;
+import java.time.LocalDate;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
@@ -22,10 +27,9 @@ import java.util.stream.Collectors;
 @Component
 @StepScope
 @RequiredArgsConstructor
-public class DailyLogWriter implements ItemWriter<ContentStatistics> {
+public class DailyLogWriter implements ItemWriter<List<ContentStatistics>> {
 
     private final JdbcTemplate jdbcTemplate;
-    private static final Object GLOBAL_LOCK = new Object();
 
     private static final String INSERT_OR_UPDATE_SQL = """
             INSERT INTO content_statistics
@@ -38,45 +42,65 @@ public class DailyLogWriter implements ItemWriter<ContentStatistics> {
             """;
 
     @Override
-    @Transactional(isolation = Isolation.SERIALIZABLE)
-    public void write(Chunk<? extends ContentStatistics> chunk) {
-        List<ContentStatistics> sortedItems = chunk.getItems().stream()
-                .sorted(Comparator.comparing(stats -> stats.getContentPost().getId()))
-                .collect(Collectors.toList());
+    @Transactional(isolation = Isolation.READ_COMMITTED)
+    public void write(Chunk<? extends List<ContentStatistics>> chunk) {
+        if (chunk.isEmpty()) {
+            return;
+        }
 
-        Map<Long, List<ContentStatistics>> groupedStats = sortedItems.stream()
-                .collect(Collectors.groupingBy(stats -> stats.getContentPost().getId()));
+        List<ContentStatistics> allStats = chunk.getItems().stream()
+                .flatMap(List::stream)
+                .sorted(Comparator.comparing((ContentStatistics stats) -> stats.getContentPost().getId())
+                        .thenComparing(ContentStatistics::getStatisticsDate))
+                .toList();
 
-        synchronized (GLOBAL_LOCK) {
-            for (Map.Entry<Long, List<ContentStatistics>> entry : groupedStats.entrySet()) {
-                List<ContentStatistics> statsGroup = entry.getValue();
-                ContentPost contentPost = statsGroup.get(0).getContentPost();
-                long totalWatchTime = 0;
+        Map<Pair<Long, LocalDate>, List<ContentStatistics>> groupedStats =
+                allStats.stream().collect(Collectors.groupingBy(
+                        stats -> Pair.of(stats.getContentPost().getId(), stats.getStatisticsDate())
+                ));
 
-                List<Object[]> batchArgs = new ArrayList<>();
-                for (ContentStatistics stats : statsGroup) {
-                    totalWatchTime += stats.getWatchTime();
-                    batchArgs.add(new Object[]{
-                            contentPost.getId(),
-                            stats.getStatisticsDate(),
-                            stats.getPeriod().name(),
-                            stats.getViewCount(),
-                            stats.getWatchTime(),
-                            contentPost.getTotalViews()
-                    });
-                }
+        for (Map.Entry<Pair<Long, LocalDate>, List<ContentStatistics>> entry : groupedStats.entrySet()) {
+            saveStatisticsWithRetry(entry.getValue());
+        }
+    }
 
-                contentPost.addWatchTime(totalWatchTime);
-                try {
-                    jdbcTemplate.batchUpdate(INSERT_OR_UPDATE_SQL, batchArgs);
-                    log.debug("Processed {} statistics entries for content {}", 
-                            statsGroup.size(), contentPost.getId());
-                } catch (Exception e) {
-                    log.error("Error while writing statistics for content {}", 
-                            contentPost.getId(), e);
-                    throw e;
-                }
-            }
+    @Retryable(
+            retryFor = {CannotAcquireLockException.class},
+            maxAttempts = 5,
+            backoff = @Backoff(delay = 1000, multiplier = 2)
+    )
+    private void saveStatisticsWithRetry(List<ContentStatistics> statsGroup) {
+        ContentPost contentPost = statsGroup.getFirst().getContentPost();
+        LocalDate statisticsDate = statsGroup.getFirst().getStatisticsDate();
+
+        long totalViews = statsGroup.stream().mapToLong(ContentStatistics::getViewCount).sum();
+        long totalWatchTime = statsGroup.stream().mapToLong(ContentStatistics::getWatchTime).sum();
+
+        // 일간, 주간, 월간 통계 순차적 저장
+        for (StatisticsPeriod period : StatisticsPeriod.getAllPeriodsForDaily()) {
+            saveStatistics(contentPost, statisticsDate, period, totalViews, totalWatchTime);
+        }
+    }
+
+    @Retryable(
+            retryFor = {CannotAcquireLockException.class},
+            maxAttempts = 3,
+            backoff = @Backoff(delay = 1000)
+    )
+    private void saveStatistics(ContentPost contentPost, LocalDate date, StatisticsPeriod period,
+                                long viewCount, long watchTime) {
+        int updatedRows = jdbcTemplate.update(INSERT_OR_UPDATE_SQL,
+                contentPost.getId(),
+                date,
+                period.name(),
+                viewCount,
+                watchTime,
+                contentPost.getTotalViews()
+        );
+
+        if (updatedRows == 0) {
+            log.warn("통계가 업데이트되지 않았습니다: 컨텐츠 ID={}, 날짜={}, 기간={}",
+                    contentPost.getId(), date, period);
         }
     }
 }

--- a/src/main/java/com/github/garamflow/streamsettlement/entity/statistics/ContentStatistics.java
+++ b/src/main/java/com/github/garamflow/streamsettlement/entity/statistics/ContentStatistics.java
@@ -45,7 +45,11 @@ public class ContentStatistics {
     @Column(name = "accumulated_views")
     private Long accumulatedViews;
 
-    public ContentStatistics(Builder builder) {
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    private ContentStatistics(Builder builder) {
         this.contentPost = builder.contentPost;
         this.statisticsDate = builder.statisticsDate;
         this.period = builder.period;
@@ -61,6 +65,9 @@ public class ContentStatistics {
         private Long viewCount;
         private Long watchTime;
         private Long accumulatedViews;
+
+        public Builder() {
+        }
 
         public Builder contentPost(ContentPost contentPost) {
             this.contentPost = contentPost;

--- a/src/main/java/com/github/garamflow/streamsettlement/entity/statistics/StatisticsPeriod.java
+++ b/src/main/java/com/github/garamflow/streamsettlement/entity/statistics/StatisticsPeriod.java
@@ -1,5 +1,7 @@
 package com.github.garamflow.streamsettlement.entity.statistics;
 
+import java.util.List;
+
 public enum StatisticsPeriod {
     DAILY("일간"), WEEKLY("주간"), MONTHLY("월간"), YEARLY("연간");
 
@@ -7,5 +9,9 @@ public enum StatisticsPeriod {
 
     StatisticsPeriod(String description) {
         this.description = description;
+    }
+
+    public static List<StatisticsPeriod> getAllPeriodsForDaily() {
+        return List.of(DAILY, WEEKLY, MONTHLY, YEARLY);
     }
 }

--- a/src/main/java/com/github/garamflow/streamsettlement/repository/statistics/ContentStatisticsRepository.java
+++ b/src/main/java/com/github/garamflow/streamsettlement/repository/statistics/ContentStatisticsRepository.java
@@ -9,7 +9,6 @@ import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDate;
 import java.util.List;
-import java.util.Optional;
 
 public interface ContentStatisticsRepository extends JpaRepository<ContentStatistics, Long> {
     List<ContentStatistics> findTop5ByPeriodAndStatisticsDateOrderByViewCountDesc(
@@ -20,19 +19,13 @@ public interface ContentStatisticsRepository extends JpaRepository<ContentStatis
             StatisticsPeriod period, LocalDate date, Pageable pageable
     );
 
-    @Query("SELECT s FROM ContentStatistics s JOIN FETCH s.contentPost WHERE s.statisticsDate = :date")
-    List<ContentStatistics> findAllWithContentPostByDate(@Param("date") LocalDate date);
+    @Query("SELECT cs FROM ContentStatistics cs WHERE cs.period = :period AND cs.statisticsDate = :date")
+    List<ContentStatistics> findByPeriodAndDate(
+            @Param("period") StatisticsPeriod period,
+            @Param("date") LocalDate date
+    );
 
-    @Query("""
-                SELECT COALESCE(MAX(cs.accumulatedViews), 0)
-                FROM ContentStatistics cs
-                WHERE cs.contentPost.id = :contentId
-                AND cs.statisticsDate < :date
-                AND cs.period = :period
-            """)
-    Optional<Long> findLastAccumulatedViews(
-            @Param("contentId") Long contentId,
-            @Param("date") LocalDate date,
-            @Param("period") StatisticsPeriod period
+    List<ContentStatistics> findByPeriodAndStatisticsDate(
+            StatisticsPeriod period, LocalDate date
     );
 }

--- a/src/test/java/com/github/garamflow/streamsettlement/batch/config/DailyLogAggregationJobConfigTest.java
+++ b/src/test/java/com/github/garamflow/streamsettlement/batch/config/DailyLogAggregationJobConfigTest.java
@@ -17,16 +17,16 @@ import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.batch.core.*;
-import org.springframework.batch.item.ExecutionContext;
 import org.springframework.batch.test.JobLauncherTestUtils;
 import org.springframework.batch.test.JobRepositoryTestUtils;
 import org.springframework.batch.test.context.SpringBatchTest;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.dao.EmptyResultDataAccessException;
 
 import java.time.LocalDate;
-import java.util.Collection;
+import java.util.ArrayList;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -68,34 +68,56 @@ class DailyLogAggregationJobConfigTest {
     @BeforeEach
     void setUp() {
         jobRepositoryTestUtils.removeJobExecutions();
-
-        // 데이터 초기화
         contentStatisticsRepository.deleteAll();
         viewLogRepository.deleteAll();
         advertisementContentPostRepository.deleteAll();
         contentPostRepository.deleteAll();
         memberRepository.deleteAll();
-
-        // 테스트용 데이터 생성
-        Member member = createMember();
-        ContentPost contentPost = createContentPost(member);
-        createCompletedViewLogs(member, contentPost, LocalDate.now());
-    }
-
-
-    @BeforeEach
-    void setUpJobLauncher() {
-        jobLauncherTestUtils.setJob(dailyLogAggregationJob);
     }
 
     @Test
-    void 일간_통계_집계_Job이_파티셔닝_정상_작동시_실행된다() throws Exception {
+    void 일간_주간_월간_통계_집계_Job이_정상적으로_실행된다() throws Exception {
         // given
-        LocalDate today = LocalDate.now();
+        LocalDate targetDate = LocalDate.now();
+        // 데이터가 없는 경우를 테스트하기 위해 데이터베이스를 비웁니다.
+        viewLogRepository.deleteAll();
 
         JobParameters jobParameters = new JobParametersBuilder()
-                .addString("targetDate", today.toString())
-                .addString("gridSize", "5")
+                .addString("targetDate", targetDate.toString())
+                .addString("gridSize", "2")
+                .addLong("timestamp", System.currentTimeMillis())
+                .toJobParameters();
+
+        // when
+        JobExecution jobExecution = null;
+        try {
+            jobExecution = jobLauncherTestUtils.launchJob(jobParameters);
+        } catch (EmptyResultDataAccessException e) {
+            // 데이터가 없는 경우 예외가 발생할 수 있습니다.
+            log.warn("No data found for target date: {}", targetDate, e);
+        }
+
+        // then
+        assertThat(jobExecution).isNotNull();
+        assertThat(jobExecution.getStatus()).isEqualTo(BatchStatus.COMPLETED);
+
+        // 데이터가 없는 경우에도 통계 데이터가 없는지 확인합니다.
+        List<ContentStatistics> dailyStats = contentStatisticsRepository.findByPeriodAndStatisticsDate(
+                StatisticsPeriod.DAILY, targetDate);
+        assertThat(dailyStats).isEmpty();
+    }
+
+    @Test
+    void 데이터가_있는_경우_통계가_정상적으로_집계된다() throws Exception {
+        // given
+        Member member = createMember();
+        ContentPost contentPost = createContentPost(member);
+        LocalDate targetDate = LocalDate.now();
+        createViewLogs(member, contentPost, targetDate, 5);  // 5개의 로그 생성
+
+        JobParameters jobParameters = new JobParametersBuilder()
+                .addString("targetDate", targetDate.toString())
+                .addString("gridSize", "2")
                 .addLong("timestamp", System.currentTimeMillis())
                 .toJobParameters();
 
@@ -105,41 +127,48 @@ class DailyLogAggregationJobConfigTest {
         // then
         assertThat(jobExecution.getStatus()).isEqualTo(BatchStatus.COMPLETED);
 
-        List<ContentStatistics> statistics = contentStatisticsRepository.findAll();
-        assertThat(statistics)
-                .hasSize(1)
-                .allSatisfy(stat -> {
-                    assertThat(stat.getPeriod()).isEqualTo(StatisticsPeriod.DAILY);
-                    assertThat(stat.getViewCount()).isEqualTo(3L);
-                    assertThat(stat.getWatchTime()).isGreaterThan(0L);
-                });
-
-        log.info("Job이 성공적으로 실행되었습니다. 총 통계 데이터 건수: {}", statistics.size());
+        List<ContentStatistics> dailyStats = contentStatisticsRepository.findByPeriodAndStatisticsDate(
+                StatisticsPeriod.DAILY, targetDate);
+        assertThat(dailyStats).isNotEmpty();
+        assertThat(dailyStats.get(0).getViewCount()).isEqualTo(5);
     }
 
     @Test
-    void 잘못된_Job_파라미터가_입력되면_예외가_발생한다() {
+    void 잘못된_날짜_형식으로_Job을_실행하면_실패한다() throws Exception {
         // given
-        JobParameters invalidParameters = new JobParametersBuilder()
-                .addString("targetDate", "invalid-date") // 잘못된 날짜 형식
-                .addString("gridSize", "5")
+        JobParameters jobParameters = new JobParametersBuilder()
+                .addString("targetDate", "invalid-date")
+                .addString("gridSize", "2")
+                .addLong("timestamp", System.currentTimeMillis())
                 .toJobParameters();
 
         // when & then
-        assertThatThrownBy(() -> jobLauncherTestUtils.launchJob(invalidParameters))
+        assertThatThrownBy(() -> jobLauncherTestUtils.launchJob(jobParameters))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("Invalid 'targetDate' format");
     }
 
+    @Test
+    void targetDate_파라미터가_없으면_실패한다() throws Exception {
+        // given
+        JobParameters jobParameters = new JobParametersBuilder()
+                .addString("gridSize", "2")
+                .addLong("timestamp", System.currentTimeMillis())
+                .toJobParameters();
+
+        // when & then
+        assertThatThrownBy(() -> jobLauncherTestUtils.launchJob(jobParameters))
+                .isInstanceOf(JobParametersInvalidException.class)
+                .hasMessageContaining("The JobParameters do not contain required keys: [targetDate]");
+    }
 
     @Test
-    void 일간_통계_집계_Job이_정상적으로_실행된다() throws Exception {
+    void 데이터가_없는_날짜로_Job을_실행하면_정상_완료된다() throws Exception {
         // given
-        LocalDate today = LocalDate.now();
-
+        LocalDate emptyDate = LocalDate.now().plusDays(1); // 미래 날짜로 테스트
         JobParameters jobParameters = new JobParametersBuilder()
-                .addString("targetDate", today.toString()) // targetDate 전달
-                .addString("gridSize", "5")
+                .addString("targetDate", emptyDate.toString())
+                .addString("gridSize", "2")
                 .addLong("timestamp", System.currentTimeMillis())
                 .toJobParameters();
 
@@ -149,67 +178,86 @@ class DailyLogAggregationJobConfigTest {
         // then
         assertThat(jobExecution.getStatus()).isEqualTo(BatchStatus.COMPLETED);
 
-        List<ContentStatistics> statistics = contentStatisticsRepository.findAll();
-        assertThat(statistics)
-                .hasSize(1)
-                .allSatisfy(stat -> {
-                    assertThat(stat.getPeriod()).isEqualTo(StatisticsPeriod.DAILY);
-                    assertThat(stat.getViewCount()).isEqualTo(3L);
-                    assertThat(stat.getWatchTime()).isGreaterThan(0L);
-                });
-
-        log.info("Job이 성공적으로 실행되었습니다. 총 통계 데이터 건수: {}", statistics.size());
+        List<ContentStatistics> dailyStats = contentStatisticsRepository.findByPeriodAndStatisticsDate(
+                StatisticsPeriod.DAILY, emptyDate);
+        assertThat(dailyStats).isEmpty();
     }
 
     @Test
-    void 파티셔너가_올바르게_파티션을_생성한다() throws Exception {
+    void 단일_파티션으로_데이터를_처리할_수_있다() throws Exception {
         // given
-        LocalDate today = LocalDate.now();
         Member member = createMember();
         ContentPost contentPost = createContentPost(member);
-        createCompletedViewLogs(member, contentPost, today);  // 테스트 데이터 생성
-        
+        LocalDate targetDate = LocalDate.now();
+        createViewLogs(member, contentPost, targetDate, 100);
+
         JobParameters jobParameters = new JobParametersBuilder()
-                .addString("targetDate", today.toString())
-                .addString("gridSize", "5")
+                .addString("targetDate", targetDate.toString())
+                .addString("gridSize", "1")  // 단일 파티션으로 테스트
                 .addLong("timestamp", System.currentTimeMillis())
                 .toJobParameters();
 
         // when
-        JobExecution jobExecution = jobLauncherTestUtils.launchStep(
-                "masterStep",
-                jobParameters
-        );
+        JobExecution jobExecution = jobLauncherTestUtils.launchJob(jobParameters);
 
         // then
         assertThat(jobExecution.getStatus()).isEqualTo(BatchStatus.COMPLETED);
-        
-        // 파티션 Step 실행 결과 확인
-        Collection<StepExecution> stepExecutions = jobExecution.getStepExecutions();
-        assertThat(stepExecutions)
-                .isNotEmpty()
-                .hasSizeGreaterThanOrEqualTo(2); // masterStep과 최소 1개 이상의 workerStep
-
-        // workerStep들의 실행 결과 확인
-        List<StepExecution> workerSteps = stepExecutions.stream()
-                .filter(execution -> execution.getStepName().startsWith("workerStep"))
-                .toList();
-
-        assertThat(workerSteps)
-                .isNotEmpty()
-                .allSatisfy(execution -> {
-                    assertThat(execution.getStatus()).isEqualTo(BatchStatus.COMPLETED);
-                    assertThat(execution.getReadCount()).isPositive();
-                });
-        
-        // 로그 출력을 통한 디버깅
-        log.info("Step Executions: {}", stepExecutions);
-        stepExecutions.forEach(execution -> {
-            log.info("Step Name: {}", execution.getStepName());
-            log.info("Execution Context: {}", execution.getExecutionContext());
-        });
+        List<ContentStatistics> dailyStats = contentStatisticsRepository.findByPeriodAndStatisticsDate(
+                StatisticsPeriod.DAILY, targetDate);
+        assertThat(dailyStats).isNotEmpty();
+        assertThat(dailyStats.get(0).getViewCount()).isEqualTo(100);
     }
 
+    @Test
+//    @Disabled("실제 운영 환경에서만 멀티 파티션 테스트 수행")
+    void 멀티_파티션_테스트() throws Exception {
+        // given
+        Member member = createMember();
+        ContentPost contentPost = createContentPost(member);
+        LocalDate targetDate = LocalDate.now();
+        createViewLogs(member, contentPost, targetDate, 100);
+
+        JobParameters jobParameters = new JobParametersBuilder()
+                .addString("targetDate", targetDate.toString())
+                .addString("gridSize", "4")  // 멀티 파티션으로 테스트
+                .addLong("timestamp", System.currentTimeMillis())
+                .toJobParameters();
+
+        // when
+        JobExecution jobExecution = jobLauncherTestUtils.launchJob(jobParameters);
+
+        // then
+        assertThat(jobExecution.getStatus()).isEqualTo(BatchStatus.COMPLETED);
+        List<ContentStatistics> dailyStats = contentStatisticsRepository.findByPeriodAndStatisticsDate(
+                StatisticsPeriod.DAILY, targetDate);
+        assertThat(dailyStats).isNotEmpty();
+        assertThat(dailyStats.get(0).getViewCount()).isEqualTo(100);
+    }
+
+    @Test
+    void 과거_날짜의_데이터도_처리할_수_있다() throws Exception {
+        // given
+        Member member = createMember();
+        ContentPost contentPost = createContentPost(member);
+        LocalDate pastDate = LocalDate.now().minusDays(7);
+        createViewLogs(member, contentPost, pastDate, 3);
+
+        JobParameters jobParameters = new JobParametersBuilder()
+                .addString("targetDate", pastDate.toString())
+                .addString("gridSize", "1")
+                .addLong("timestamp", System.currentTimeMillis())
+                .toJobParameters();
+
+        // when
+        JobExecution jobExecution = jobLauncherTestUtils.launchJob(jobParameters);
+
+        // then
+        assertThat(jobExecution.getStatus()).isEqualTo(BatchStatus.COMPLETED);
+        List<ContentStatistics> dailyStats = contentStatisticsRepository.findByPeriodAndStatisticsDate(
+                StatisticsPeriod.DAILY, pastDate);
+        assertThat(dailyStats).isNotEmpty();
+        assertThat(dailyStats.get(0).getViewCount()).isEqualTo(3);
+    }
 
     private Member createMember() {
         String uniqueEmail = "test" + System.currentTimeMillis() + "@test.com";
@@ -217,8 +265,7 @@ class DailyLogAggregationJobConfigTest {
                 .email(uniqueEmail)
                 .role(Role.MEMBER)
                 .build();
-
-        return memberRepository.save(member); // 영속 상태로 저장
+        return memberRepository.save(member);
     }
 
     private ContentPost createContentPost(Member member) {
@@ -227,24 +274,22 @@ class DailyLogAggregationJobConfigTest {
                 .title("테스트 영상")
                 .url("http://test.com/video")
                 .build();
-
         return contentPostRepository.save(contentPost);
     }
 
-    private void createCompletedViewLogs(Member member, ContentPost contentPost, LocalDate date) {
-        // 완료된 로그 3개 생성
-        for (int i = 0; i < 3; i++) {
+    private List<DailyMemberViewLog> createViewLogs(Member member, ContentPost contentPost, LocalDate date, int count) {
+        List<DailyMemberViewLog> logs = new ArrayList<>();
+        for (int i = 0; i < count; i++) {
             DailyMemberViewLog viewLog = DailyMemberViewLog.builder()
                     .member(member)
                     .contentPost(contentPost)
                     .lastViewedPosition(100 * (i + 1))
                     .lastAdViewCount(i)
-                    .logDate(date)  // 파라미터로 받은 날짜 사용
+                    .logDate(date)
                     .status(StreamingStatus.COMPLETED)
                     .build();
-
-            DailyMemberViewLog savedViewLog = viewLogRepository.save(viewLog);
-            log.info("저장된 로그: {}", savedViewLog);
+            logs.add(viewLogRepository.save(viewLog));
         }
+        return logs;
     }
 }

--- a/src/test/java/com/github/garamflow/streamsettlement/batch/reader/DailyLogReaderTest.java
+++ b/src/test/java/com/github/garamflow/streamsettlement/batch/reader/DailyLogReaderTest.java
@@ -5,35 +5,27 @@ import com.github.garamflow.streamsettlement.entity.member.Role;
 import com.github.garamflow.streamsettlement.entity.stream.Log.DailyMemberViewLog;
 import com.github.garamflow.streamsettlement.entity.stream.Log.StreamingStatus;
 import com.github.garamflow.streamsettlement.entity.stream.content.ContentPost;
+import com.github.garamflow.streamsettlement.repository.advertisement.AdvertisementContentPostRepository;
+import com.github.garamflow.streamsettlement.repository.statistics.ContentStatisticsRepository;
 import com.github.garamflow.streamsettlement.repository.stream.ContentPostRepository;
 import com.github.garamflow.streamsettlement.repository.stream.DailyMemberViewLogRepository;
 import com.github.garamflow.streamsettlement.repository.user.MemberRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.springframework.batch.core.*;
-import org.springframework.batch.core.launch.JobLauncher;
 import org.springframework.batch.item.database.JdbcPagingItemReader;
+import org.springframework.batch.test.context.SpringBatchTest;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.jdbc.core.JdbcTemplate;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @SpringBootTest
-@ExtendWith(SpringExtension.class)
+@SpringBatchTest
 class DailyLogReaderTest {
-
-    @Autowired
-    private JdbcTemplate jdbcTemplate;
 
     @Autowired
     private DailyLogReader dailyLogReader;
@@ -48,37 +40,33 @@ class DailyLogReaderTest {
     private ContentPostRepository contentPostRepository;
 
     @Autowired
-    private JobLauncher jobLauncher;
+    private ContentStatisticsRepository contentStatisticsRepository;
 
     @Autowired
-    private Job dailyLogAggregationJob;
+    private AdvertisementContentPostRepository advertisementContentPostRepository;
 
     @BeforeEach
     void setUp() {
-        jdbcTemplate.execute("DELETE FROM daily_member_view_log");
-        jdbcTemplate.execute("DELETE FROM content_statistics");
-        jdbcTemplate.execute("DELETE FROM advertisement_content_post");
-        jdbcTemplate.execute("DELETE FROM content_post");
-        jdbcTemplate.execute("DELETE FROM member");
+        contentStatisticsRepository.deleteAll();
+        advertisementContentPostRepository.deleteAll();
+        viewLogRepository.deleteAll();
+        contentPostRepository.deleteAll();
+        memberRepository.deleteAll();
     }
 
     @Test
-    void reader는_특정_날짜의_로그를_모두_읽어온다() throws Exception {
+    void 특정_날짜의_로그를_정상적으로_읽어온다() throws Exception {
         // given
-        LocalDate targetDate = LocalDate.of(2024, 3, 20);
+        LocalDate targetDate = LocalDate.now();
         Member member = createMember();
         ContentPost contentPost = createContentPost(member);
-        createViewLogs(member, contentPost, targetDate);
+        List<DailyMemberViewLog> createdLogs = createViewLogs(member, contentPost, targetDate, 3);
 
-        Map<String, Object> minMax = jdbcTemplate.queryForMap("""
-                SELECT MIN(content_post_id) as min_id, 
-                       MAX(content_post_id) as max_id 
-                FROM content_post
-                """);
+        // ID 범위 설정
+        long minId = createdLogs.get(0).getId();
+        long maxId = createdLogs.get(createdLogs.size() - 1).getId();
 
-        Long minId = ((Number) minMax.get("min_id")).longValue();
-        Long maxId = ((Number) minMax.get("max_id")).longValue();
-
+        // when
         JdbcPagingItemReader<DailyMemberViewLog> reader = dailyLogReader.reader(
                 targetDate.toString(),
                 minId,
@@ -86,54 +74,51 @@ class DailyLogReaderTest {
         );
         reader.afterPropertiesSet();
 
-        // when
-        List<DailyMemberViewLog> results = new ArrayList<>();
-        DailyMemberViewLog item;
-        while ((item = reader.read()) != null) {
-            results.add(item);
+        // then
+        List<DailyMemberViewLog> logs = new ArrayList<>();
+        DailyMemberViewLog log;
+        while ((log = reader.read()) != null) {
+            logs.add(log);
         }
 
-        // then
-        assertThat(results).hasSize(3);
-        assertThat(results).allMatch(log -> {
-            assertThat(log.getLogDate()).isEqualTo(targetDate);
-            assertThat(log.getStatus()).isEqualTo(StreamingStatus.COMPLETED);
-            assertThat(log.getMember()).isEqualTo(member);
-            assertThat(log.getContentPost()).isEqualTo(contentPost);
-            return true;
-        });
+        assertThat(logs)
+                .hasSize(3)
+                .allSatisfy(viewLog -> {
+                    assertThat(viewLog.getMember()).isEqualTo(member);
+                    assertThat(viewLog.getContentPost()).isEqualTo(contentPost);
+                    assertThat(viewLog.getLogDate()).isEqualTo(targetDate);
+                    assertThat(viewLog.getStatus()).isEqualTo(StreamingStatus.COMPLETED);
+                });
     }
 
     @Test
-    void reader가_minId_또는_maxId_누락시_예외를_던진다() {
+    void ID_범위를_벗어난_로그는_읽지_않는다() throws Exception {
         // given
-        LocalDate targetDate = LocalDate.of(2024, 3, 20);
+        LocalDate targetDate = LocalDate.now();
+        Member member = createMember();
+        ContentPost contentPost = createContentPost(member);
+        List<DailyMemberViewLog> createdLogs = createViewLogs(member, contentPost, targetDate, 5);
 
-        // when & then
-        assertThatThrownBy(() -> dailyLogReader.reader(targetDate.toString(), null, 100L))
-                .isInstanceOf(IllegalStateException.class)
-                .hasMessageContaining("StepExecutionContext missing 'minId' or 'maxId'");
-
-        assertThatThrownBy(() -> dailyLogReader.reader(targetDate.toString(), 1L, null))
-                .isInstanceOf(IllegalStateException.class)
-                .hasMessageContaining("StepExecutionContext missing 'minId' or 'maxId'");
-    }
-
-
-    @Test
-    void testJobExecution() throws Exception {
-        // given
-        LocalDate targetDate = LocalDate.of(2024, 3, 20);
-        JobParameters jobParameters = new JobParametersBuilder()
-                .addString("targetDate", targetDate.toString())
-                .addLong("time", System.currentTimeMillis())
-                .toJobParameters();
+        // ID 범위 설정
+        long minId = createdLogs.get(0).getId();
+        long maxId = createdLogs.get(2).getId(); // 처음 3개만 읽도록 설정
 
         // when
-        JobExecution jobExecution = jobLauncher.run(dailyLogAggregationJob, jobParameters);
+        JdbcPagingItemReader<DailyMemberViewLog> reader = dailyLogReader.reader(
+                targetDate.toString(),
+                minId,
+                maxId
+        );
+        reader.afterPropertiesSet();
 
         // then
-        assertEquals(BatchStatus.COMPLETED, jobExecution.getStatus());
+        List<DailyMemberViewLog> logs = new ArrayList<>();
+        DailyMemberViewLog log;
+        while ((log = reader.read()) != null) {
+            logs.add(log);
+        }
+
+        assertThat(logs).hasSize(3);
     }
 
     private Member createMember() {
@@ -154,16 +139,19 @@ class DailyLogReaderTest {
         return contentPostRepository.save(contentPost);
     }
 
-    private void createViewLogs(Member member, ContentPost contentPost, LocalDate date) {
-        for (int i = 0; i < 3; i++) {
-            viewLogRepository.save(DailyMemberViewLog.builder()
+    private List<DailyMemberViewLog> createViewLogs(Member member, ContentPost contentPost, LocalDate date, int count) {
+        List<DailyMemberViewLog> logs = new ArrayList<>();
+        for (int i = 0; i < count; i++) {
+            DailyMemberViewLog viewLog = DailyMemberViewLog.builder()
                     .member(member)
                     .contentPost(contentPost)
                     .lastViewedPosition(100 * (i + 1))
                     .lastAdViewCount(i)
                     .logDate(date)
                     .status(StreamingStatus.COMPLETED)
-                    .build());
+                    .build();
+            logs.add(viewLogRepository.save(viewLog));
         }
+        return logs;
     }
 }


### PR DESCRIPTION
- 일간, 주간, 월간, 연간 기준으로 콘텐츠 통계를 집계하는 배치 처리 기능 추가
- 배치 작업 구성 요소에 대한 단위 테스트 및 통합 테스트 구현
- `DailyLogAggregationJobConfig`, `DailyLogPartitioner`, `DailyLogProcessor`, `DailyMemberViewLogRowMapper`, `DailyLogReader`, `StatisticsUtil`, `DailyLogWriter` 업데이트
- `DailyLogWriterTest`, `DailyLogReaderTest`, `DailyLogProcessorTest`, `DailyLogAggregationJobConfigTest`를 통해 기능 검증 완료