### PR TITLE
perf: 조회수 0인 데이터 필터링으로 배치 성능 개선

### DIFF
--- a/src/main/java/com/github/garamflow/streamsettlement/batch/partition/DailyLogPartitioner.java
+++ b/src/main/java/com/github/garamflow/streamsettlement/batch/partition/DailyLogPartitioner.java
@@ -36,6 +36,7 @@ public class DailyLogPartitioner implements Partitioner {
                            COUNT(*) as total_count
                     FROM daily_member_view_log
                     WHERE log_date = ?
+                    AND last_viewed_position > 0
                     """;
 
             Map<String, Object> result = jdbcTemplate.queryForMap(sql, targetDate);

--- a/src/main/java/com/github/garamflow/streamsettlement/batch/reader/DailyLogReader.java
+++ b/src/main/java/com/github/garamflow/streamsettlement/batch/reader/DailyLogReader.java
@@ -76,6 +76,7 @@ public class DailyLogReader {
         queryProvider.setWhereClause("""
                 d.log_date = :targetDate
                 AND d.daily_member_view_log_id BETWEEN :minId AND :maxId
+                AND d.last_viewed_position > 0
                 """);
         queryProvider.setSortKeys(Map.of("d.daily_member_view_log_id", Order.ASCENDING));
         return queryProvider;

--- a/src/test/java/com/github/garamflow/streamsettlement/batch/performance/BatchPerformanceTest.java
+++ b/src/test/java/com/github/garamflow/streamsettlement/batch/performance/BatchPerformanceTest.java
@@ -1,0 +1,132 @@
+package com.github.garamflow.streamsettlement.batch.performance;
+
+import com.github.garamflow.streamsettlement.batch.TestDataGenerator;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.JobExecution;
+import org.springframework.batch.core.JobParameters;
+import org.springframework.batch.core.JobParametersBuilder;
+import org.springframework.batch.core.launch.JobLauncher;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.time.LocalDate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Slf4j
+@SpringBootTest
+@ActiveProfiles("test")
+class BatchPerformanceTest {
+
+    @Autowired
+    private JobLauncher jobLauncher;
+
+    @Autowired
+    private Job dailyLogAggregationJob;
+
+    @Autowired
+    private TestDataGenerator testDataGenerator;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @BeforeEach
+    void setUp() {
+        testDataGenerator.clearAllData();
+    }
+
+    @DisplayName("배치 처리 성능 테스트")
+    @ParameterizedTest
+    @ValueSource(ints = {100000})
+        // 데이터 크기별 테스트
+    void batchPerformanceTest(int dataSize) throws Exception {
+        // Given
+        generateTestData(dataSize);
+
+        // 데이터 현황 상세 로깅
+        String countSql = """
+                SELECT
+                    COUNT(*) as total_count,
+                    SUM(CASE WHEN last_viewed_position = 0 THEN 1 ELSE 0 END) as zero_view_count,
+                    SUM(CASE WHEN last_viewed_position > 0 THEN 1 ELSE 0 END) as non_zero_view_count,
+                    MIN(last_viewed_position) as min_position,
+                    MAX(last_viewed_position) as max_position,
+                    AVG(last_viewed_position) as avg_position
+                FROM daily_member_view_log
+                WHERE log_date = ?
+                """;
+
+        jdbcTemplate.query(
+                countSql,
+                ps -> ps.setObject(1, LocalDate.now()),
+                rs -> {
+                    log.info("""
+                                    
+                                    테스트 데이터 현황:
+                                    전체 데이터: {}
+                                    조회수 0인 데이터: {} ({}%)
+                                    조회수 있는 데이터: {} ({}%)
+                                    조회 위치 범위: {} ~ {} (평균: {})
+                                    """,
+                            rs.getInt("total_count"),
+                            rs.getInt("zero_view_count"),
+                            String.format("%.1f", rs.getInt("zero_view_count") * 100.0 / rs.getInt("total_count")),
+                            rs.getInt("non_zero_view_count"),
+                            String.format("%.1f", rs.getInt("non_zero_view_count") * 100.0 / rs.getInt("total_count")),
+                            rs.getInt("min_position"),
+                            rs.getInt("max_position"),
+                            String.format("%.1f", rs.getDouble("avg_position"))
+                    );
+                }
+        );
+
+        // When
+        JobParameters parameters = new JobParametersBuilder()
+                .addString("targetDate", LocalDate.now().toString())
+                .addLong("timestamp", System.currentTimeMillis())
+                .toJobParameters();
+
+        long startTime = System.currentTimeMillis();
+        JobExecution execution = jobLauncher.run(dailyLogAggregationJob, parameters);
+        long endTime = System.currentTimeMillis();
+
+        // Then
+        double executionTime = (endTime - startTime) / 1000.0;  // 초 단위
+        int processedCount = jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM content_statistics", Integer.class);
+        double tps = processedCount / executionTime;
+
+        log.info("""
+                        
+                        성능 테스트 결과 (데이터 크기: {})
+                        총 실행 시간: {}초
+                        처리된 레코드 수: {}
+                        TPS: {}
+                        작업 상태: {}""",
+                dataSize,
+                String.format("%.2f", executionTime),
+                processedCount,
+                String.format("%.2f", tps),
+                execution.getStatus());
+
+        assertThat(execution.getStatus().isUnsuccessful()).isFalse();
+        assertThat(processedCount).isGreaterThan(0);
+    }
+
+    private void generateTestData(int size) {
+        // 기본 테스트 데이터 생성
+        testDataGenerator.createTestData(
+                size / 100,  // 멤버 수
+                size / 10, // 콘텐츠 수
+                size / 100,  // 광고 수
+                size         // 조회 로그 수
+        );
+    }
+} 


### PR DESCRIPTION
- DailyLogPartitioner에서 조회수 0인 데이터를 필터링하여 파티션 생성
- 실제 통계 처리가 필요한 데이터만 파티셔닝하여 처리 성능 향상
- 배치 성능 테스트 코드 추가하여 성능 개선 검증

조회수가 0인 데이터는 통계 처리가 불필요하므로, 파티셔닝 단계에서
last_viewed_position > 0 조건을 추가하여 필터링합니다.
이를 통해 불필요한 데이터 처리를 줄이고 배치 처리 성능을 개선했습니다.