### PR TITLE
refactor: DailyLogWriter의 데이터 처리 로직을 Repository 계층으로 이동

### DIFF
--- a/src/main/java/com/github/garamflow/streamsettlement/batch/writer/DailyLogWriter.java
+++ b/src/main/java/com/github/garamflow/streamsettlement/batch/writer/DailyLogWriter.java
@@ -1,58 +1,28 @@
 package com.github.garamflow.streamsettlement.batch.writer;
 
 import com.github.garamflow.streamsettlement.entity.statistics.ContentStatistics;
+import com.github.garamflow.streamsettlement.repository.statistics.ContentStatisticsRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.batch.item.Chunk;
 import org.springframework.batch.item.ItemWriter;
-import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.annotation.Isolation;
-import org.springframework.transaction.annotation.Transactional;
 
-import java.sql.PreparedStatement;
+import java.util.Comparator;
 import java.util.List;
 
 @Slf4j
 @Component
 @RequiredArgsConstructor
 public class DailyLogWriter implements ItemWriter<List<ContentStatistics>> {
-
-    private final JdbcTemplate jdbcTemplate;
-    private static final int BATCH_SIZE = 500;
-
-    private static final String INSERT_SQL = """
-            INSERT IGNORE INTO content_statistics
-            (content_post_id, statistics_date, period, view_count, watch_time, accumulated_views)
-            VALUES (?, ?, ?, ?, ?, ?)
-            """;
+    private final ContentStatisticsRepository contentStatisticsRepository;
 
     @Override
-    @Transactional(isolation = Isolation.READ_COMMITTED)
     public void write(Chunk<? extends List<ContentStatistics>> chunk) {
-        if (chunk.isEmpty()) {
-            return;
-        }
-
         List<ContentStatistics> allStats = chunk.getItems().stream()
                 .flatMap(List::stream)
+                .sorted(Comparator.comparing(stat -> stat.getContentPost().getId()))
                 .toList();
-
-        try {
-            jdbcTemplate.batchUpdate(INSERT_SQL,
-                    allStats,
-                    allStats.size(),
-                    (PreparedStatement ps, ContentStatistics stat) -> {
-                        ps.setLong(1, stat.getContentPost().getId());
-                        ps.setObject(2, stat.getStatisticsDate());
-                        ps.setString(3, stat.getPeriod().name());
-                        ps.setLong(4, stat.getViewCount());
-                        ps.setLong(5, stat.getWatchTime());
-                        ps.setLong(6, stat.getAccumulatedViews());
-                    });
-        } catch (Exception e) {
-            log.error("Error during bulk insert", e);
-            throw new RuntimeException("Bulk insert failed", e);
-        }
+        contentStatisticsRepository.bulkInsertStatistics(allStats);
     }
 }

--- a/src/main/java/com/github/garamflow/streamsettlement/repository/statistics/ContentStatisticsCustomRepository.java
+++ b/src/main/java/com/github/garamflow/streamsettlement/repository/statistics/ContentStatisticsCustomRepository.java
@@ -1,0 +1,9 @@
+package com.github.garamflow.streamsettlement.repository.statistics;
+
+import com.github.garamflow.streamsettlement.entity.statistics.ContentStatistics;
+
+import java.util.List;
+
+public interface ContentStatisticsCustomRepository {
+    void bulkInsertStatistics(List<ContentStatistics> statistics);
+} 

--- a/src/main/java/com/github/garamflow/streamsettlement/repository/statistics/ContentStatisticsCustomRepositoryImpl.java
+++ b/src/main/java/com/github/garamflow/streamsettlement/repository/statistics/ContentStatisticsCustomRepositoryImpl.java
@@ -1,0 +1,47 @@
+package com.github.garamflow.streamsettlement.repository.statistics;
+
+import com.github.garamflow.streamsettlement.entity.statistics.ContentStatistics;
+import lombok.RequiredArgsConstructor;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class ContentStatisticsCustomRepositoryImpl implements ContentStatisticsCustomRepository {
+    private final NamedParameterJdbcTemplate namedParameterJdbcTemplate;
+
+    @Override
+    @Transactional
+    public void bulkInsertStatistics(List<ContentStatistics> statistics) {
+        String sql = """
+                INSERT INTO content_statistics
+                (content_post_id, statistics_date, period, view_count, watch_time, accumulated_views)
+                VALUES (:contentPostId, :statisticsDate, :period, :viewCount, :watchTime, :accumulatedViews)
+                ON DUPLICATE KEY UPDATE
+                    view_count = view_count + VALUES(view_count),
+                    watch_time = watch_time + VALUES(watch_time),
+                    accumulated_views = GREATEST(accumulated_views, VALUES(accumulated_views))
+                """;
+        namedParameterJdbcTemplate.batchUpdate(sql, getStatisticsParameterSources(statistics));
+    }
+
+    private MapSqlParameterSource[] getStatisticsParameterSources(List<ContentStatistics> statistics) {
+        return statistics.stream()
+                .map(this::getStatisticsParameterSource)
+                .toArray(MapSqlParameterSource[]::new);
+    }
+
+    private MapSqlParameterSource getStatisticsParameterSource(ContentStatistics stat) {
+        return new MapSqlParameterSource()
+                .addValue("contentPostId", stat.getContentPost().getId())
+                .addValue("statisticsDate", stat.getStatisticsDate())
+                .addValue("period", stat.getPeriod().name())
+                .addValue("viewCount", stat.getViewCount())
+                .addValue("watchTime", stat.getWatchTime())
+                .addValue("accumulatedViews", stat.getAccumulatedViews());
+    }
+} 

--- a/src/main/java/com/github/garamflow/streamsettlement/repository/statistics/ContentStatisticsRepository.java
+++ b/src/main/java/com/github/garamflow/streamsettlement/repository/statistics/ContentStatisticsRepository.java
@@ -10,7 +10,8 @@ import java.time.LocalDate;
 import java.util.List;
 
 @Repository
-public interface ContentStatisticsRepository extends JpaRepository<ContentStatistics, Long> {
+public interface ContentStatisticsRepository extends JpaRepository<ContentStatistics, Long>, ContentStatisticsCustomRepository {
+
     List<ContentStatistics> findTop5ByPeriodAndStatisticsDateOrderByViewCountDesc(
             StatisticsPeriod period, LocalDate date, Pageable pageable
     );


### PR DESCRIPTION
- JdbcTemplate 직접 사용 로직을 ContentStatisticsRepository로 이동
- 비즈니스 로직과 데이터 접근 로직의 관심사 분리
- INSERT IGNORE 대신 ON DUPLICATE KEY UPDATE 구문으로 변경하여 통계 데이터 누적 처리
- Repository 패턴에 맞게 테스트 코드 리팩토링