### PR TITLE
feat: ContentPost 캐시 적용으로 DB 조회 최적화

### DIFF
--- a/src/main/java/com/github/garamflow/streamsettlement/batch/processor/StatisticsItemProcessor.java
+++ b/src/main/java/com/github/garamflow/streamsettlement/batch/processor/StatisticsItemProcessor.java
@@ -4,8 +4,8 @@ import com.github.garamflow.streamsettlement.batch.dto.CumulativeStatisticsDto;
 import com.github.garamflow.streamsettlement.entity.statistics.ContentStatistics;
 import com.github.garamflow.streamsettlement.entity.statistics.StatisticsPeriod;
 import com.github.garamflow.streamsettlement.entity.stream.content.ContentPost;
-import com.github.garamflow.streamsettlement.repository.statistics.ContentStatisticsRepository;
 import com.github.garamflow.streamsettlement.repository.stream.ContentPostRepository;
+import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.batch.core.configuration.annotation.StepScope;
@@ -15,8 +15,10 @@ import org.springframework.lang.NonNull;
 import org.springframework.stereotype.Component;
 
 import java.time.LocalDate;
+import java.util.Map;
 import java.util.NoSuchElementException;
-import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+
 
 @Component
 @StepScope
@@ -25,35 +27,40 @@ import java.util.Optional;
 public class StatisticsItemProcessor implements ItemProcessor<CumulativeStatisticsDto, ContentStatistics> {
 
     private final ContentPostRepository contentPostRepository;
-    private final ContentStatisticsRepository contentStatisticsRepository;
+    private final Map<Long, ContentPost> contentPostCache = new ConcurrentHashMap<>(1000);
+
 
     @Value("#{jobParameters['targetDate']}")
     private LocalDate targetDate;
 
+    @PostConstruct
+    public void init() {
+        log.info("Initializing content post cache...");
+        contentPostRepository.findAll()
+                .forEach(content -> {
+                    contentPostCache.put(content.getId(), content);
+                    log.debug("Cached content: id={}, totalViews={}", 
+                            content.getId(), content.getTotalViews());
+                });
+        log.info("Content post cache initialized with {} items", contentPostCache.size());
+    }
+
     @Override
     public ContentStatistics process(@NonNull CumulativeStatisticsDto dto) {
-        // ContentPost 조회
-        ContentPost contentPost = contentPostRepository.findById(dto.contentId())
-                .orElseThrow(() -> new NoSuchElementException("ContentPost not found"));
-
-        // 기존 통계 조회
-        Optional<ContentStatistics> latest = contentStatisticsRepository
-                .findByContentPost_IdAndPeriodAndStatisticsDate(
-                        dto.contentId(),
-                        StatisticsPeriod.DAILY,
-                        targetDate
-                );
-
-        long accumulatedViews = latest.map(ContentStatistics::getAccumulatedViews)
-                .orElse(contentPost.getTotalViews()); // 기존 통계 없으면 contentPost.totalViews() 사용
+        ContentPost contentPost = contentPostCache.computeIfAbsent(dto.contentId(), id -> {
+            log.debug("Cache miss for content id: {}. Loading from database...", id);
+            return contentPostRepository.findById(id)
+                    .orElseThrow(() -> new NoSuchElementException(
+                            String.format("ContentPost not found in cache or database for id: %d", id)));
+        });
 
         return ContentStatistics.existingBuilder()
                 .contentPost(contentPost)
                 .statisticsDate(targetDate)
                 .period(StatisticsPeriod.DAILY)
-                .viewCount(dto.totalViews())           // 이미 집계된 일일 조회수
-                .watchTime(dto.totalWatchTime())       // 이미 집계된 일일 재생시간
-                .accumulatedViews(accumulatedViews)    // 누적 뷰
+                .viewCount(dto.totalViews())
+                .watchTime(dto.totalWatchTime())
+                .accumulatedViews(contentPost.getTotalViews())
                 .build();
     }
 }

--- a/src/main/java/com/github/garamflow/streamsettlement/entity/statistics/ContentStatistics.java
+++ b/src/main/java/com/github/garamflow/streamsettlement/entity/statistics/ContentStatistics.java
@@ -16,7 +16,9 @@ import java.util.Optional;
 @Table(name = "content_statistics",
 indexes = {
   @Index(name = "idx_content_statistics_id_date", 
-         columnList = "content_statistics_id, statistics_date")
+         columnList = "content_statistics_id, statistics_date"),
+  @Index(name = "idx_content_statistics_composite", 
+         columnList = "content_post_id, period, statistics_date")
 })
 public class ContentStatistics {
 

--- a/src/main/java/com/github/garamflow/streamsettlement/repository/statistics/ContentStatisticsQuerydslRepository.java
+++ b/src/main/java/com/github/garamflow/streamsettlement/repository/statistics/ContentStatisticsQuerydslRepository.java
@@ -4,9 +4,7 @@ import com.github.garamflow.streamsettlement.batch.dto.CumulativeStatisticsDto;
 import com.github.garamflow.streamsettlement.batch.dto.QCumulativeStatisticsDto;
 import com.github.garamflow.streamsettlement.entity.statistics.ContentStatistics;
 import com.github.garamflow.streamsettlement.entity.statistics.StatisticsPeriod;
-import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
-import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -40,13 +38,6 @@ public class ContentStatisticsQuerydslRepository {
                 .where(dateEq(date))
                 .fetchOne();
         return result != null ? result : 0L;
-    }
-
-    public List<ContentStatistics> findByStatisticsDate(LocalDate date) {
-        return jpaQueryFactory
-                .selectFrom(contentStatistics)
-                .where(dateEq(date))
-                .fetch();
     }
 
     /**
@@ -98,29 +89,6 @@ public class ContentStatisticsQuerydslRepository {
                 .fetch();
     }
 
-
-    public List<ContentStatistics> findByIdBetweenAndStatisticsDate(Long startId, Long endId, LocalDate date) {
-        return jpaQueryFactory
-                .selectFrom(contentStatistics)
-                .where(
-                        idBetween(startId, endId),
-                        dateEq(date)
-                )
-                .orderBy(contentStatistics.id.asc())
-                .fetch();
-    }
-
-    public List<ContentStatistics> findByContentPostIdAndStatisticsDateBetween(
-            Long contentPostId, LocalDate startDate, LocalDate endDate) {
-        return jpaQueryFactory
-                .selectFrom(contentStatistics)
-                .where(
-                        contentPostIdEq(contentPostId),
-                        betweenDates(startDate, endDate)
-                )
-                .fetch();
-    }
-
     public List<ContentStatistics> findTop5ByViewCount(StatisticsPeriod period, LocalDate date) {
         return jpaQueryFactory
                 .selectFrom(contentStatistics)
@@ -138,30 +106,6 @@ public class ContentStatisticsQuerydslRepository {
                 .limit(5)
                 .fetch();
     }
-
-    public List<ContentStatistics> findStatisticsByCondition(Long cursorId, LocalDate statisticsDate, StatisticsPeriod period, Long fetchSize) {
-        return jpaQueryFactory
-                .selectFrom(contentStatistics)
-                .where(
-                        dateEq(statisticsDate),
-                        periodEq(period),
-                        cursorCondition(cursorId)
-                )
-                .orderBy(contentStatistics.id.asc())
-                .limit(fetchSize)
-                .fetch();
-    }
-
-    public List<ContentStatistics> findByIdBetweenAndStatisticsDateOrderByContentPostId(
-            Long startId, Long endId, LocalDate date) {
-        return jpaQueryFactory
-                .selectFrom(contentStatistics)
-                .where(idBetween(startId, endId), dateEq(date))
-                .orderBy(contentStatistics.contentPost.id.asc())
-                .fetch();
-    }
-
-    // --- 추가 메서드 시작 ---
 
     /**
      * 기간(From~To)과 기간타입에 해당하는 통계 조회
@@ -218,42 +162,8 @@ public class ContentStatisticsQuerydslRepository {
         return contentStatistics.statisticsDate.eq(date);
     }
 
-    private BooleanExpression idBetween(Long startId, Long endId) {
-        return contentStatistics.id.between(startId, endId);
-    }
-
     private BooleanExpression betweenDates(LocalDate startDate, LocalDate endDate) {
         return contentStatistics.statisticsDate.between(startDate, endDate);
-    }
-
-    private BooleanExpression contentPostIdEq(Long contentPostId) {
-        return contentPostId != null ? contentStatistics.contentPost.id.eq(contentPostId) : null;
-    }
-
-    private BooleanExpression cursorCondition(Long cursorId) {
-        return cursorId == null ? null : contentStatistics.id.goe(cursorId);
-    }
-
-    public List<CumulativeStatisticsDto> findDailyStatisticsByContentIdBetween(
-            Long startContentId, Long endContentId, LocalDate targetDate) {
-        return jpaQueryFactory
-                .select(Projections.constructor(CumulativeStatisticsDto.class,
-                        contentStatistics.contentPost.id,
-                        contentStatistics.viewCount.sum(),
-                        contentStatistics.watchTime.sum(),
-                        Expressions.constant(0L)))
-                .from(contentStatistics)
-                .where(
-                        contentPostIdBetween(startContentId, endContentId),
-                        dateEq(targetDate)
-                )
-                .groupBy(contentStatistics.contentPost.id)
-                .orderBy(contentStatistics.contentPost.id.asc())
-                .fetch();
-    }
-
-    private BooleanExpression contentPostIdBetween(Long startId, Long endId) {
-        return contentStatistics.contentPost.id.between(startId, endId);
     }
 }
 


### PR DESCRIPTION
- ContentPost 조회를 위한 ConcurrentHashMap 캐시 도입
- 애플리케이션 시작 시 모든 ContentPost 데이터 캐시 적재
- 캐시 미스 시 DB 조회 후 캐시 갱신 로직 추가
- 로깅 추가로 캐시 동작 모니터링 개선

성능 개선:
- 반복적인 DB 조회 감소
- 배치 처리 속도 향상